### PR TITLE
adding API VERSION BY MODEL/YEAR

### DIFF
--- a/PhilipsTV.js
+++ b/PhilipsTV.js
@@ -4,9 +4,28 @@ const wol = require('wake_on_lan');
 class PhilipsTV {
     constructor(config) {
         this.config = config;
-        this.apiUrl = `https://${config.ip_address}:1926/6/`;
+        
         this.wolURL = config.wol_url;
+        this.model_year = config.model_year;
+        this.model_year_nr = parseInt(this.model_year);
+    
+        // CHOOSING API VERSION BY MODEL/YEAR
+        switch (this.model_year_nr) {
+            case 2016:
+                this.api_version = 6;
+                break;
+            case 2014:
+                this.api_version = 5;
+                break;
+            default:
+                this.api_version = 1;
+            }
+        // CONNECTION SETTINGS
+        this.protocol = (this.api_version > 5) ? 'https' : 'http';
+        this.portno = (this.api_version > 5) ? '1926' : '1925';
+        this.apiUrl = `${this.protocol}://${config.ip_address}:${this.portno}/${this.api_version}/`;
     }
+
 
     api(path, body = null) {
         return new Promise((resolve, reject) => {

--- a/config.schema.json
+++ b/config.schema.json
@@ -14,7 +14,7 @@
                 "default": "Name of the Accessory"
             },
             "ip_address": {
-                "title": "IP_address V4",
+                "title": "IP address V4",
                 "type": "string",
                 "format": "ipv4",
                 "description": "IP address of the Television"
@@ -58,12 +58,19 @@
                 "items": {
                     "type": "object",
                     "properties": {
-                        "name": {
+                        "name": { "type": "string", "description": "Name of the input" },
+                        "type": {
                             "type": "string",
-                            "description": "Name of the channel"
+                            "enum": ["channel", "launch"],
+                            "description": "Type of input"
+                        },
+                        "channel": {
+                            "type": "number",
+                            "description": "Number of the channel - Only use this when Channel is selected"
                         },
                         "launch": {
                             "type": "object",
+                            "description": "Launch Application configuration - Do NOT fill this when Channel is selected",
                             "properties": {
                                 "intent": {
                                     "type": "object",
@@ -71,34 +78,25 @@
                                         "component": {
                                             "type": "object",
                                             "properties": {
-                                                "packageName": {
-                                                    "type": "string"
-                                                },
-                                                "className": {
-                                                    "type": "string"
-                                                }
+                                                "packageName": { "type": "string" },
+                                                "className": { "type": "string" }
                                             }
                                         },
-                                        "action": {
-                                            "type": "string"
-                                        }
+                                        "action": { "type": "string" }
                                     }
                                 }
                             }
-                        },
-                        "channel": {
-                            "type": "string",
-                            "description": "Number of the channel"
                         }
-                    }
+                    },
+                    "required": ["name", "type"]
                 }
-            },
-            "required": [
-                "name",
-                "ip_address",
-                "poll_status_interval",
-                "model_year"
-            ]
-        }
+            }
+        },
+        "required": [
+            "name",
+            "ip_address",
+            "poll_status_interval",
+            "model_year"
+        ]
     }
 }

--- a/config.schema.json
+++ b/config.schema.json
@@ -1,0 +1,105 @@
+{
+    "title": "Homebridge PhilipsTV Accessory Configuration",
+    "pluginAlias": "PhilipsTV",
+    "pluginType": "accessory",
+    "singular": false,
+    "headerDisplay": "Homebridge plugin for PhilipsTV.",
+    "footerDisplay": "For additional information visit [Plugin Homepage](https://github.com/m2ert/homebridge)",
+    "schema": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "title": "Name",
+          "type": "string",
+          "default": "Name of the Accessory"
+        },
+        "ip_address": {
+          "title": "IP_address V4",
+          "type": "string",
+          "format": "ipv4",
+          "description": "IP address of the Television"
+        },
+        "poll_status_interval": {
+          "title": "Poll interval",
+          "type": "integer",
+          "minimum": 5,
+          "default": 30,
+          "description": "Polling interval of the TV"
+        },
+        "model_year": {
+          "title": "Model Year",
+          "type": "integer",
+          "default": 2016,
+          "description": "Model year of the TV"
+        },
+        "has_ambilight": {
+          "title": "Ambilight",
+          "type": "boolean",
+          "default": false,
+          "description": "Whether the TV has Ambilight feature exposed to Homebridge"
+        },
+        "wol_url": {
+          "title": "WOL url",
+          "type": "string",
+          "description": "Wake On LAN for TV"
+        },
+        "username": {
+          "title": "User Name",
+          "type": "string",
+          "description": "API username for TV"
+        },
+        "password": {
+          "title": "Password",
+          "type": "string",
+          "description": "API password for TV"
+        },
+        "inputs": {
+            "type": "list",
+            "name": {
+              "title": "Name",
+              "type": "string",
+              "description": "Name of the Accessory"
+            },
+            "launch": {
+
+                "intent": {
+                  "component" : {
+                    "packageName": {
+                      "title": "packageName",
+                      "type": "string",
+                      "description": "Name off the App service"
+                    }
+                    "className": {
+                      "title": "className",
+                      "type": "string",
+                      "description": "endpoint off the App service"
+                    }
+                  },
+                  "action": {
+                    "title": "Action",
+                    "type": "string",
+                    "description": "Program to execute on action"
+                  }
+
+              }
+          },
+          "name": {
+            "title": "Name",
+            "type": "string",
+            "description": "Name of the channel"
+           },
+          "channel": {
+            "title": "Name",
+            "type": "enom",
+            "description": "Nummer of the channel"
+          }
+        },
+        "required": [
+          "name",
+          "ip_address",
+          "poll_status_interval",
+          "model_year"
+        ]
+    }
+  }
+}

--- a/config.schema.json
+++ b/config.schema.json
@@ -6,100 +6,99 @@
     "headerDisplay": "Homebridge plugin for PhilipsTV.",
     "footerDisplay": "For additional information visit [Plugin Homepage](https://github.com/m2ert/homebridge)",
     "schema": {
-      "type": "object",
-      "properties": {
-        "name": {
-          "title": "Name",
-          "type": "string",
-          "default": "Name of the Accessory"
-        },
-        "ip_address": {
-          "title": "IP_address V4",
-          "type": "string",
-          "format": "ipv4",
-          "description": "IP address of the Television"
-        },
-        "poll_status_interval": {
-          "title": "Poll interval",
-          "type": "integer",
-          "minimum": 5,
-          "default": 30,
-          "description": "Polling interval of the TV"
-        },
-        "model_year": {
-          "title": "Model Year",
-          "type": "integer",
-          "default": 2016,
-          "description": "Model year of the TV"
-        },
-        "has_ambilight": {
-          "title": "Ambilight",
-          "type": "boolean",
-          "default": false,
-          "description": "Whether the TV has Ambilight feature exposed to Homebridge"
-        },
-        "wol_url": {
-          "title": "WOL url",
-          "type": "string",
-          "description": "Wake On LAN for TV"
-        },
-        "username": {
-          "title": "User Name",
-          "type": "string",
-          "description": "API username for TV"
-        },
-        "password": {
-          "title": "Password",
-          "type": "string",
-          "description": "API password for TV"
-        },
-        "inputs": {
-            "type": "list",
+        "type": "object",
+        "properties": {
             "name": {
-              "title": "Name",
-              "type": "string",
-              "description": "Name of the Accessory"
+                "title": "Name",
+                "type": "string",
+                "default": "Name of the Accessory"
             },
-            "launch": {
-
-                "intent": {
-                  "component" : {
-                    "packageName": {
-                      "title": "packageName",
-                      "type": "string",
-                      "description": "Name off the App service"
+            "ip_address": {
+                "title": "IP_address V4",
+                "type": "string",
+                "format": "ipv4",
+                "description": "IP address of the Television"
+            },
+            "poll_status_interval": {
+                "title": "Poll interval",
+                "type": "integer",
+                "minimum": 5,
+                "default": 30,
+                "description": "Polling interval of the TV"
+            },
+            "model_year": {
+                "title": "Model Year",
+                "type": "integer",
+                "default": 2016,
+                "description": "Model year of the TV"
+            },
+            "has_ambilight": {
+                "title": "Ambilight",
+                "type": "boolean",
+                "default": false,
+                "description": "Whether the TV has Ambilight feature exposed to Homebridge"
+            },
+            "wol_url": {
+                "title": "WOL url",
+                "type": "string",
+                "description": "Wake On LAN for TV"
+            },
+            "username": {
+                "title": "User Name",
+                "type": "string",
+                "description": "API username for TV"
+            },
+            "password": {
+                "title": "Password",
+                "type": "string",
+                "description": "API password for TV"
+            },
+            "inputs": {
+                "type": "array",
+                "items": {
+                    "type": "object",
+                    "properties": {
+                        "name": {
+                            "type": "string",
+                            "description": "Name of the channel"
+                        },
+                        "launch": {
+                            "type": "object",
+                            "properties": {
+                                "intent": {
+                                    "type": "object",
+                                    "properties": {
+                                        "component": {
+                                            "type": "object",
+                                            "properties": {
+                                                "packageName": {
+                                                    "type": "string"
+                                                },
+                                                "className": {
+                                                    "type": "string"
+                                                }
+                                            }
+                                        },
+                                        "action": {
+                                            "type": "string"
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "channel": {
+                            "type": "string",
+                            "description": "Number of the channel"
+                        }
                     }
-                    "className": {
-                      "title": "className",
-                      "type": "string",
-                      "description": "endpoint off the App service"
-                    }
-                  },
-                  "action": {
-                    "title": "Action",
-                    "type": "string",
-                    "description": "Program to execute on action"
-                  }
-
-              }
-          },
-          "name": {
-            "title": "Name",
-            "type": "string",
-            "description": "Name of the channel"
-           },
-          "channel": {
-            "title": "Name",
-            "type": "enom",
-            "description": "Nummer of the channel"
-          }
-        },
-        "required": [
-          "name",
-          "ip_address",
-          "poll_status_interval",
-          "model_year"
-        ]
+                }
+            },
+            "required": [
+                "name",
+                "ip_address",
+                "poll_status_interval",
+                "model_year"
+            ]
+        }
     }
-  }
 }


### PR DESCRIPTION
with this the plugin also support older models off Philips TV

also added a config.schema.json file for Homebridge UI

All the fields are always visible, but for a channel there is only the channel number that needs to be filled in,
the other fields need to be filled in when using a application/launch

This is because;
- The Homebridge UI only supports "conditional" for top-level config fields.
- If you want dynamic UI inside array items, you need to use "oneOf" (which the UI also does not fully support), or you must flatten your structure.
- or the plugin needs a rewrite to have separate arrays:
1.              channels: array of channel objects
2.              launches: array of launch objects 

Kind regards